### PR TITLE
fix unset LOG_CONCURRENCY crashing apps

### DIFF
--- a/profile/WEB_CONCURRENCY.sh
+++ b/profile/WEB_CONCURRENCY.sh
@@ -30,6 +30,6 @@ export MEMORY_AVAILABLE=${MEMORY_AVAILABLE-$(detect_memory 512)}
 export WEB_MEMORY=${WEB_MEMORY-512}
 export WEB_CONCURRENCY=$(calculate_concurrency)
 
-if [ "$LOG_CONCURRENCY" = "true" ]; then
+if [[ "${LOG_CONCURRENCY+isset}" && "$LOG_CONCURRENCY" == "true" ]]; then
   log_concurrency
 fi


### PR DESCRIPTION
if an app has a .profile.d script that does set -u, and that is evaluated before WEB_CONCURRENCY.sh (because of alpha order when globbing), the access to the variable, if unset, would cause a failure on startup

the fix is to check if the variable is set, using the '+' parameter substitution